### PR TITLE
Adding Text Alignment Property in ToolTip

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <img src="tooltip.svg" alt="tooltip" width="100" height="100">
   </a>
 
-  <h3 align="center">Angular Drag and Drop</h3>
+  <h3 align="center">Angular Tooltip</h3>
 
   <p align="center">
     Tooltip directive adds a behavior to elements in your Angular applications where you can add a tooltip
@@ -126,6 +126,7 @@ Angular Tooltip has flags where you can customize your component:
 |Horizontal tooltip position, positive numbers will push it to the left, while negative numbers will push it to the right|`leftOffset`|`0`|`-99999...99999`|`number`|
 |Vertical tooltip position, positive numbers will push it down, while negative numbers will push it up.|`topOffset`|`0`|`-99999...99999`|`number`|
 |Allows for breaking lines withing the same word.|`wordBreak`|`none`|`Any string`|`string`|
+|Text Alignment.|`textAlign`|`none`|`Any string`|`string`|
 |Only shows the tooltip if the text is overflowed (not entirely showing up, with '...').|`showOnlyIfOverflowEllipsis`|`false`|`true/false`|`boolean`|
 
 Usage example
@@ -136,6 +137,7 @@ Usage example
     leftOffset="30"
     topOffset="23"
     wordBreak="Cut"
+    textAlign="right"
     showOnlyIfOverflowEllipsis="true">
     <button
     class="upload-button">Upload Documents</button>

--- a/projects/angular-tooltip/README.md
+++ b/projects/angular-tooltip/README.md
@@ -128,6 +128,7 @@ Usage example
     leftOffset="30"
     topOffset="23"
     wordBreak="Cut"
+    textAlign="right"
     showOnlyIfOverflowEllipsis="true">
     <button
     class="upload-button">Upload Documents</button>

--- a/projects/angular-tooltip/src/lib/tooltip.component.ts
+++ b/projects/angular-tooltip/src/lib/tooltip.component.ts
@@ -15,6 +15,7 @@ export class TooltipComponent {
   @HostBinding('style.left') hostStyleLeft: string;
   @HostBinding('style.width') hostStyleWidth: string;
   @HostBinding('style.word-break') hostWordBreak: string;
+  @HostBinding('style.text-align') hostStyleTextAlign: string;
   @HostBinding('class.tooltip-show') hostClassShow: boolean;
 
   @Input() set show(show: boolean) {
@@ -77,6 +78,9 @@ export class TooltipComponent {
     if (this.wordBreak) {
       this.hostWordBreak = this.wordBreak;
     }
+    if (this.textAlign) {
+      this.hostStyleTextAlign = this.textAlign;
+    }
   }
 
   get placement() {
@@ -109,5 +113,9 @@ export class TooltipComponent {
 
   get wordBreak(): string {
     return this.data.wordBreak;
+  }
+
+  get textAlign(): string {
+    return this.data.textAlign;
   }
 }

--- a/projects/angular-tooltip/src/lib/tooltip.directive.ts
+++ b/projects/angular-tooltip/src/lib/tooltip.directive.ts
@@ -25,6 +25,7 @@ export class TooltipDirective {
   @Input('topOffset') topOffset = 0;
   @Input('customWidth') customWidth: string;
   @Input('wordBreak') wordBreak: string;
+  @Input('textAlign') textAlign: string;
   @Input('showOnlyIfOverflowEllipsis') showOnlyIfOverflowEllipsis: boolean;
 
   get isTooltipDestroyed() {
@@ -112,7 +113,8 @@ export class TooltipDirective {
       leftOffset: this.leftOffset,
       topOffset: this.topOffset,
       customWidth: this.customWidth,
-      wordBreak: this.wordBreak
+      wordBreak: this.wordBreak,
+      textAlign: this.textAlign
     };
 
     this.appRef.attachView(this.componentRef.hostView);


### PR DESCRIPTION
Adding parameters to set text alignment in tooltip using 'style.text-align' property.
- Inclusion of the new 'textAlign' property, which receives a string, to define the text alignment within the tooltip;
- Inclusion of @HostBinding for 'style.text-align';
- Inclusion of new 'textAlign' property in the README;